### PR TITLE
Remove storage link command from Dockerfile

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -38,9 +38,6 @@ RUN composer install --optimize-autoloader --no-interaction --no-scripts
 # Phân quyền cho Laravel
 RUN chown -R www-data:www-data storage bootstrap/cache
 
-# Tạo link storage
-RUN php artisan storage:link
-
 # Mở port 8000 và chạy Laravel
 EXPOSE 8080
 CMD php artisan serve --host=0.0.0.0 --port=8080


### PR DESCRIPTION
Removed the command to create a storage link in Laravel.